### PR TITLE
feat: activate demo dashboard and data layer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Core
+NODE_ENV=development
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+EXPO_PUBLIC_APP_URL=exp://localhost:8081
+DATABASE_FILE=data/database.json
+KNOWLEDGE_BASE_FILE=data/knowledge-base.json
+DEFAULT_USER_EMAIL=founder@example.com
+
+# Feature Flags (JSON or comma-separated overrides)
+FEATURE_FLAGS={"voice":true}
+
+# Analytics
+ANALYTICS_FLUSH_INTERVAL=5000

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+node_modules
+.pnpm-store
+.next
+expo
+.dist
+build
+dist
+.DS_Store
+.env
+.env.local
+.vscode
+.idea
+coverage

--- a/README.md
+++ b/README.md
@@ -1,1 +1,86 @@
-# app-boilerplate
+# Full-Stack AI App Boilerplate
+
+Spin up a production-flavoured AI SaaS demo in minutes. This monorepo bundles a Next.js dashboard, Expo mobile shell, shared UI systems, an in-memory datastore, seed scripts, and mocked integrations for auth, payments, chat, voice, analytics, and email. Clone the repo, run a single command, and explore the fully wired experience without touching any code.
+
+## TL;DR
+
+```bash
+pnpm bootstrap   # installs deps, prepares the demo datastore, ingests docs
+pnpm dev         # runs the Next.js demo dashboard
+```
+
+The bootstrap script copies `.env.example`, installs workspace dependencies, creates a JSON datastore under `data/`, seeds demo users/products/messages, and ingests markdown docs into the knowledge base. No Docker or external services are required—the integrations are mocked so everything works out-of-the-box.
+
+## Demo Features
+
+The seeded dashboard highlights the major modules you can extend:
+
+- **Authentication** – A demo founder account with mock session management.
+- **Stripe-style billing** – Pricing table, active subscription, and customer portal links.
+- **AI chat** – Deterministic assistant that summarises prompts and streams responses.
+- **Voice** – Simulated transcription + TTS preview data seeded for the dashboard.
+- **Knowledge base** – Markdown is converted into vector-ready embeddings for RAG demos.
+- **Analytics & audit logs** – Events and audit entries tracked as you seed and interact.
+- **Email** – Resend-style campaign stats plus sample transactional email logging.
+
+All of these modules live in dedicated packages under `packages/` and expose simple TypeScript APIs so you can swap the mocked implementations for real infrastructure when you are ready.
+
+## Repository Layout
+
+```
+apps/
+  web/       # Next.js dashboard that stitches every module together
+  admin/     # Placeholder admin console (wire it up to @app/api when needed)
+  docs/      # Static developer docs scaffold
+  mobile/    # Expo entry point that consumes the shared UI-native kit
+packages/
+  analytics/ # Event + audit tracking backed by the JSON datastore
+  api/       # Aggregated helpers consumed by the dashboard and admin app
+  auth/      # Demo auth/session helpers with deterministic hashing
+  chat/      # Chat runtime that calls the lightweight LLM adapter
+  config/    # Environment + feature flag loader built on zod
+  db/        # File-backed datastore helpers (read/write JSON)
+  email/     # Mock email + campaign helpers that touch audit logs
+  llm/       # Provider-agnostic chat abstractions (mocked here)
+  payments/  # Stripe-style product + checkout helpers
+  ui/        # Web design system (unstyled React components with inline styles)
+  ui-native/ # React Native counterparts used by the Expo shell
+  utils/     # Shared utility helpers (IDs, formatting, math)
+  voice/     # Voice session mocks (ASR/TTS)
+scripts/
+  bootstrap.ts  # Copies envs, installs deps, seeds + ingests demo data
+  migrate.ts    # Ensures the JSON datastore exists
+  seed.ts       # Seeds demo users, products, chat threads, analytics, voice, email
+  ingest.ts     # Converts markdown into the knowledge base entries
+```
+
+## Quickstart
+
+1. **Install** – Run `pnpm bootstrap`. Pass `--skip-install` or `--skip-data` if you only need part of the workflow.
+2. **Explore** – Start the web demo with `pnpm dev --filter @app/web`. Visit [http://localhost:3000](http://localhost:3000) to explore the dashboard.
+3. **Hack** – Modify packages under `packages/` and the dashboard will hot-reload thanks to Next.js transpiling workspace packages.
+4. **Scripts** – Re-run `pnpm db:seed` to reset demo data or `pnpm kb:ingest` after editing markdown in `docs/knowledge-base/`.
+
+## Environment
+
+Configuration is controlled through `.env`:
+
+```ini
+NODE_ENV=development
+DATABASE_FILE=data/database.json
+KNOWLEDGE_BASE_FILE=data/knowledge-base.json
+DEFAULT_USER_EMAIL=founder@example.com
+FEATURE_FLAGS={"voice":true}
+```
+
+You can toggle modules by editing `FEATURE_FLAGS` (JSON or comma-separated `flag=true/false`) and reloading the dashboard.
+
+## Extending the Template
+
+- Replace the mocked datastore in `@app/db` with Prisma or your preferred ORM. The rest of the modules only rely on the exported helper functions.
+- Swap the `@app/llm` implementation with OpenAI/Anthropic SDK calls. The chat UI will stream whatever you return.
+- Wire `@app/payments` to Stripe Checkout + Billing customer portals.
+- Expand `apps/admin` and `apps/mobile` using the shared UI systems for a consistent feel.
+
+The goal is to provide an opinionated starting point that demonstrates the complete product surface area (auth, billing, chat, voice, analytics, docs) so you can iterate from a working base instead of building scaffolding from scratch.
+

--- a/apps/admin/README.md
+++ b/apps/admin/README.md
@@ -1,0 +1,12 @@
+# Admin Console
+
+The admin console is a Next.js application tailored for operations teams. It exposes dashboards, customer support tooling, and system health views.
+
+## Capabilities
+
+- User management, impersonation, and audit logs.
+- Subscription and entitlement overrides.
+- Feature flag toggles and experiments.
+- Analytics dashboards powered by PostHog and Sentry data.
+
+Run alongside the web app via `pnpm dev --filter admin`.

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@app/admin",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "lint": "next lint"
+  },
+  "dependencies": {},
+  "devDependencies": {}
+}

--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -1,0 +1,13 @@
+# Documentation Site
+
+The documentation site aggregates setup guides, architecture overviews, and API references. It is built with a static site generator (Nextra by default) and deployed alongside the apps.
+
+## Structure
+
+- Getting Started
+- Feature Toggles
+- Deployment Guides
+- Security & Compliance
+- LLM Agent Quickstart
+
+Local development: `pnpm dev --filter docs`.

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@app/docs",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "npx nextra dev",
+    "build": "npx nextra build",
+    "lint": "eslint ."
+  },
+  "dependencies": {},
+  "devDependencies": {}
+}

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -1,0 +1,13 @@
+# Mobile App (Expo)
+
+The Expo React Native application shares business logic, data fetching, and UI primitives with the web client.
+
+## Highlights
+
+- Managed workflow with Expo SDK and EAS updates.
+- NativeWind-powered design system sourced from `@app/ui-native`.
+- AuthSession integration with deep links handled via `@app/auth`.
+- Stripe React Native SDK wrappers from `@app/payments`.
+- Chat + voice experiences optimized for mobile using `@app/voice`.
+
+Use `pnpm expo start` to run locally once dependencies are installed.

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@app/mobile",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "expo start",
+    "build": "expo build",
+    "lint": "eslint ."
+  },
+  "dependencies": {},
+  "devDependencies": {}
+}

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,0 +1,18 @@
+# Web App (Next.js)
+
+This Next.js 15 application is the primary web client. It consumes the shared packages for UI, API access, and authentication.
+
+## Scripts
+
+- `pnpm dev` – Start the Next.js dev server.
+- `pnpm build` – Build for production.
+- `pnpm lint` – Run lint rules shared via `@app/config`.
+
+## Features
+
+- App Router with server actions.
+- Tailwind CSS + shadcn/ui components from `@app/ui`.
+- Auth.js v5 integration via `@app/auth`.
+- tRPC + REST handlers from `@app/api`.
+- Stripe checkout + billing UI from `@app/payments`.
+- Chat + voice demos when enabled via feature flags.

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server';
+import { sendChatMessage } from '@app/chat';
+
+export async function POST(request: Request) {
+  const body = await request.json();
+  const { threadId, message } = body as { threadId?: string; message?: string };
+
+  if (!threadId || !message) {
+    return NextResponse.json({ error: 'threadId and message are required' }, { status: 400 });
+  }
+
+  try {
+    const result = sendChatMessage(threadId, message);
+    return NextResponse.json(result);
+  } catch (error) {
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 });
+  }
+}
+
+export async function GET() {
+  return NextResponse.json({ status: 'ok' });
+}
+

--- a/apps/web/app/components/ChatPanel.tsx
+++ b/apps/web/app/components/ChatPanel.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+
+interface ChatMessage {
+  id: string;
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+  createdAt: string;
+}
+
+interface ChatPanelProps {
+  threadId: string;
+  initialMessages: ChatMessage[];
+}
+
+export default function ChatPanel({ threadId, initialMessages }: ChatPanelProps) {
+  const [messages, setMessages] = useState<ChatMessage[]>(initialMessages);
+  const [input, setInput] = useState('What is included in the payments integration?');
+  const [isPending, startTransition] = useTransition();
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    const message = input.trim();
+    if (!message) return;
+
+    startTransition(async () => {
+      try {
+        const response = await fetch('/api/chat', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ threadId, message }),
+        });
+        if (!response.ok) {
+          throw new Error('Failed to send message');
+        }
+        const payload = await response.json();
+        setMessages((prev) => [...prev, payload.userMessage, payload.assistantMessage]);
+        setInput('');
+      } catch (error) {
+        console.error(error);
+      }
+    });
+  };
+
+  return (
+    <div style={{ display: 'grid', gap: '1rem' }}>
+      <div
+        style={{
+          borderRadius: 12,
+          background: 'rgba(15,23,42,0.04)',
+          padding: '1rem',
+          display: 'grid',
+          gap: '0.75rem',
+          maxHeight: 280,
+          overflowY: 'auto',
+        }}
+      >
+        {messages.map((message) => (
+          <div
+            key={message.id}
+            style={{
+              display: 'grid',
+              gap: '0.35rem',
+              justifyItems: message.role === 'user' ? 'end' : 'start',
+            }}
+          >
+            <span
+              style={{
+                padding: '0.6rem 0.9rem',
+                borderRadius: 12,
+                background: message.role === 'user' ? 'rgba(37,99,235,0.15)' : '#ffffff',
+                maxWidth: '90%',
+                boxShadow: '0 10px 24px rgba(15,23,42,0.08)',
+                color: '#0f172a',
+                fontSize: '0.95rem',
+                lineHeight: 1.4,
+              }}
+            >
+              {message.content}
+            </span>
+            <small style={{ color: 'rgba(15,23,42,0.45)' }}>
+              {new Date(message.createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+            </small>
+          </div>
+        ))}
+      </div>
+
+      <form onSubmit={handleSubmit} style={{ display: 'flex', gap: '0.75rem' }}>
+        <input
+          value={input}
+          onChange={(event) => setInput(event.target.value)}
+          placeholder="Ask the onboarder..."
+          style={{
+            flex: 1,
+            padding: '0.75rem 1rem',
+            borderRadius: 999,
+            border: '1px solid rgba(15,23,42,0.12)',
+            fontSize: '0.95rem',
+          }}
+        />
+        <button
+          type="submit"
+          disabled={isPending}
+          style={{
+            borderRadius: 999,
+            padding: '0.75rem 1.4rem',
+            background: isPending ? 'rgba(148,163,184,0.4)' : 'linear-gradient(135deg,#2563eb,#7c3aed)',
+            color: '#fff',
+            fontWeight: 600,
+            border: 'none',
+            cursor: 'pointer',
+          }}
+        >
+          {isPending ? 'Thinking...' : 'Send'}
+        </button>
+      </form>
+    </div>
+  );
+}
+

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,0 +1,21 @@
+:root {
+  color-scheme: light;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: radial-gradient(circle at top, #eef2ff, #f8fafc 58%);
+  color: #0f172a;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: transparent;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from 'next';
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: 'Full-Stack AI Boilerplate Demo',
+  description: 'Explore auth, payments, chat, voice, and analytics without writing code.',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}
+

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,0 +1,180 @@
+import Link from 'next/link';
+import { Card, Button, Badge, Metric, Grid, Stack } from '@app/ui';
+import { getDashboardSnapshot, getKnowledgeBaseDocuments, getThread } from '@app/api';
+import ChatPanel from './components/ChatPanel';
+
+export default async function Page() {
+  const dashboard = getDashboardSnapshot();
+  const docs = getKnowledgeBaseDocuments();
+  const activeThread = dashboard.chatThreads[0];
+  const threadDetail = activeThread ? getThread(activeThread.id) : null;
+
+  return (
+    <main
+      style={{
+        padding: '4rem 2rem',
+        display: 'grid',
+        gap: '2.5rem',
+        maxWidth: 1200,
+        margin: '0 auto',
+      }}
+    >
+      <header style={{ display: 'grid', gap: '1.5rem', textAlign: 'center' }}>
+        <div style={{ display: 'flex', justifyContent: 'center' }}>
+          <Badge>Full-stack AI starter</Badge>
+        </div>
+        <h1 style={{ fontSize: '3rem', margin: 0, lineHeight: 1.1 }}>
+          Ship web, mobile, chat, and voice experiences before lunch.
+        </h1>
+        <p style={{ maxWidth: 640, margin: '0 auto', fontSize: '1.1rem', color: 'rgba(15,23,42,0.65)' }}>
+          Everything runs from configuration: run the bootstrap script, start `pnpm dev`, and explore the fully-wired
+          dashboard with auth, payments, analytics, and AI chat.
+        </p>
+        <div style={{ display: 'flex', gap: '1rem', justifyContent: 'center' }}>
+          <Button href="https://github.com/" target="_blank" rel="noreferrer">
+            View docs
+          </Button>
+          <Button variant="ghost" href="https://vercel.com/" target="_blank" rel="noreferrer">
+            Deploy to Vercel
+          </Button>
+        </div>
+      </header>
+
+      <Grid columns={3}>
+        <Card
+          title="Feature toggles"
+          description="Toggle modules without touching code."
+          action={<Badge>{Object.values(dashboard.featureFlags).filter(Boolean).length} enabled</Badge>}
+        >
+          <Stack>
+            {Object.entries(dashboard.featureFlags).map(([key, value]) => (
+              <div key={key} style={{ display: 'flex', justifyContent: 'space-between', fontSize: '0.95rem' }}>
+                <span style={{ textTransform: 'capitalize' }}>{key}</span>
+                <strong style={{ color: value ? '#16a34a' : '#f97316' }}>{value ? 'On' : 'Off'}</strong>
+              </div>
+            ))}
+          </Stack>
+        </Card>
+        <Card
+          title="Subscription"
+          description={dashboard.subscription ? 'Connected to Stripe demo mode.' : 'Start on the free tier.'}
+          action={
+            dashboard.subscription ? (
+              <span style={{ color: 'rgba(15,23,42,0.65)', fontSize: '0.9rem' }}>
+                Renews {dashboard.subscription.renewalDate}
+              </span>
+            ) : null
+          }
+        >
+          <Stack>
+            {dashboard.products.map((plan) => (
+              <div key={plan.id} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                <div>
+                  <strong>{plan.name}</strong>
+                  <div style={{ fontSize: '0.85rem', color: 'rgba(15,23,42,0.65)' }}>{plan.description}</div>
+                </div>
+                <span style={{ fontWeight: 600 }}>{plan.price}/{plan.interval}</span>
+              </div>
+            ))}
+          </Stack>
+        </Card>
+        <Card title="Usage" description="Aggregated across the built-in demos.">
+          <Grid columns={3}>
+            <Metric label="Tokens" value={dashboard.usage.tokensUsed.toLocaleString()} />
+            <Metric label="Sessions" value={dashboard.usage.totalSessions.toString()} />
+            <Metric label="Latency" value={`${dashboard.usage.avgResponseTimeMs || 0} ms`} />
+          </Grid>
+        </Card>
+      </Grid>
+
+      <Grid columns={2}>
+        <Card
+          title="Live chat"
+          description="Ask the onboarder bot anything about the boilerplate."
+          action={
+            activeThread ? (
+              <span style={{ fontSize: '0.85rem', color: 'rgba(15,23,42,0.65)' }}>
+                {activeThread.messageCount} messages · avg {activeThread.avgMessageLength} chars
+              </span>
+            ) : null
+          }
+        >
+          {threadDetail ? (
+            <ChatPanel threadId={threadDetail.thread.id} initialMessages={threadDetail.messages} />
+          ) : (
+            <p>No chat threads found. Run `pnpm db:seed` to generate demo data.</p>
+          )}
+        </Card>
+
+        <Card
+          title="Knowledge base"
+          description="Ingested markdown becomes vector-ready docs for retrieval augmented generation."
+        >
+          <Stack>
+            {docs.map((doc) => (
+              <div key={doc.id} style={{ display: 'grid', gap: '0.35rem' }}>
+                <strong>{doc.title}</strong>
+                <p style={{ margin: 0, color: 'rgba(15,23,42,0.65)' }}>{doc.excerpt}...</p>
+                <span style={{ fontSize: '0.8rem', color: 'rgba(15,23,42,0.55)' }}>
+                  Updated {new Date(doc.updatedAt).toLocaleDateString()}
+                </span>
+              </div>
+            ))}
+            {!docs.length && (
+              <p>
+                Add markdown to <code>docs/knowledge-base</code> and run <code>pnpm kb:ingest</code>.
+              </p>
+            )}
+          </Stack>
+        </Card>
+      </Grid>
+
+      <Grid columns={3}>
+        <Card title="Voice sessions" description="Captured transcriptions ready for TTS playback.">
+          <Stack>
+            {dashboard.voiceSessions.map((session) => (
+              <div key={session.id} style={{ display: 'grid', gap: '0.25rem' }}>
+                <strong>{session.title}</strong>
+                <span style={{ fontSize: '0.85rem', color: 'rgba(15,23,42,0.65)' }}>
+                  {Math.max(session.durationSeconds, 1)}s · {new Date(session.createdAt).toLocaleString()}
+                </span>
+              </div>
+            ))}
+            {!dashboard.voiceSessions.length && <p>No voice sessions yet. Trigger via the voice SDK.</p>}
+          </Stack>
+        </Card>
+        <Card title="Email campaigns" description="React Email templates rendered via Resend.">
+          <Stack>
+            {dashboard.emailCampaigns.map((campaign) => (
+              <div key={campaign.id} style={{ display: 'flex', justifyContent: 'space-between' }}>
+                <div>
+                  <strong>{campaign.name}</strong>
+                  <div style={{ fontSize: '0.85rem', color: 'rgba(15,23,42,0.65)' }}>{campaign.subject}</div>
+                </div>
+                <span style={{ fontWeight: 600 }}>{Math.round((campaign.opened / campaign.delivered) * 100)}% open</span>
+              </div>
+            ))}
+          </Stack>
+        </Card>
+        <Card title="Audit & analytics" description="Every action is persisted for review.">
+          <Stack>
+            {dashboard.analytics.map((event) => (
+              <div key={event.id} style={{ display: 'grid', gap: '0.25rem' }}>
+                <strong>{event.name}</strong>
+                <span style={{ fontSize: '0.85rem', color: 'rgba(15,23,42,0.65)' }}>
+                  {new Date(event.createdAt).toLocaleString()}
+                </span>
+              </div>
+            ))}
+            {!dashboard.analytics.length && <p>No analytics events recorded yet.</p>}
+          </Stack>
+        </Card>
+      </Grid>
+
+      <footer style={{ textAlign: 'center', color: 'rgba(15,23,42,0.55)' }}>
+        Built for hacking fast. View the <Link href="/api/chat">chat API</Link> or edit feature flags in <code>.env</code>.
+      </footer>
+    </main>
+  );
+}
+

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,0 +1,22 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    typedRoutes: true,
+  },
+  transpilePackages: [
+    '@app/ui',
+    '@app/api',
+    '@app/chat',
+    '@app/utils',
+    '@app/config',
+    '@app/db',
+    '@app/auth',
+    '@app/llm',
+    '@app/payments',
+    '@app/voice',
+    '@app/email',
+    '@app/analytics',
+  ],
+};
+
+export default nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@app/web",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@app/api": "workspace:*",
+    "@app/chat": "workspace:*",
+    "@app/ui": "workspace:*",
+    "@app/utils": "workspace:*",
+    "next": "14.2.5",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.12.7",
+    "@types/react": "^18.2.46",
+    "@types/react-dom": "^18.2.17",
+    "typescript": "^5.4.5"
+  }
+}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "incremental": true,
+    "types": ["next", "next/image-types", "@types/node"],
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.cjs", "**/*.mjs"],
+  "exclude": ["node_modules"]
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3.9'
+services:
+  postgres:
+    image: ankane/pgvector:pg16
+    container_name: app-boilerplate-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: app_boilerplate
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+  redis:
+    image: redis:7
+    container_name: app-boilerplate-redis
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+    command: redis-server --save 20 1 --loglevel warning
+volumes:
+  postgres-data:

--- a/docs/knowledge-base/getting-started.md
+++ b/docs/knowledge-base/getting-started.md
@@ -1,0 +1,8 @@
+# Getting Started
+
+This document powers the knowledge-base ingestion demo. It summarises the major steps to explore the boilerplate:
+
+1. Run `pnpm bootstrap` to install dependencies, create the JSON datastore, seed demo data, and index docs.
+2. Launch the dashboard with `pnpm dev --filter @app/web`.
+3. Toggle features by editing `FEATURE_FLAGS` in `.env`.
+4. Update markdown in `docs/knowledge-base/` and re-run `pnpm kb:ingest` to refresh search results.

--- a/features.ts
+++ b/features.ts
@@ -1,0 +1,16 @@
+export const features = {
+  auth: true,
+  payments: true,
+  chat: true,
+  voice: false,
+  analytics: true,
+  emails: true,
+  uploads: true,
+  rag: false,
+};
+
+export type FeatureFlag = keyof typeof features;
+
+export function isFeatureEnabled(flag: FeatureFlag) {
+  return Boolean(features[flag]);
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "app-boilerplate",
+  "version": "0.1.0",
+  "private": true,
+  "packageManager": "pnpm@8.15.4",
+  "scripts": {
+    "bootstrap": "tsx scripts/bootstrap.ts",
+    "dev": "turbo run dev --filter=@app/web",
+    "build": "turbo run build",
+    "lint": "turbo run lint",
+    "test": "turbo run test",
+    "db:migrate": "tsx scripts/migrate.ts",
+    "db:seed": "tsx scripts/seed.ts",
+    "db:reset": "pnpm db:migrate && pnpm db:seed && pnpm kb:ingest",
+    "kb:ingest": "tsx scripts/ingest.ts"
+  },
+  "devDependencies": {
+    "dotenv": "^16.4.5",
+    "turbo": "^2.0.4",
+    "tsx": "^4.7.1",
+    "zod": "^3.23.8"
+  }
+}

--- a/packages/analytics/README.md
+++ b/packages/analytics/README.md
@@ -1,0 +1,3 @@
+# @app/analytics
+
+Analytics and observability integrations including PostHog, Sentry, Google Analytics, and Vercel Analytics. Provides hooks and server utilities for consistent instrumentation.

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@app/analytics",
+  "version": "0.1.0",
+  "private": true,
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "dependencies": {
+    "@app/db": "workspace:*",
+    "@app/utils": "workspace:*"
+  }
+}

--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -1,0 +1,24 @@
+import { getDatabase } from '@app/db';
+import { createId } from '@app/utils';
+
+export interface TrackEventPayload {
+  name: string;
+  payload: Record<string, unknown>;
+  userId?: string;
+}
+
+export function trackEvent(event: TrackEventPayload) {
+  const db = getDatabase();
+  return db.addAnalyticsEvent({
+    id: createId('evt'),
+    name: event.name,
+    payload: event.payload,
+    userId: event.userId,
+  });
+}
+
+export function listAnalyticsEvents() {
+  const db = getDatabase();
+  return db.getAnalyticsEvents().slice(-10).reverse();
+}
+

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -1,0 +1,3 @@
+# @app/api
+
+Type-safe API layer exposing tRPC routers and REST/OpenAPI handlers. Includes rate limiting, validation with Zod, and OpenAPI documentation generation.

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@app/api",
+  "version": "0.1.0",
+  "private": true,
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "dependencies": {
+    "@app/analytics": "workspace:*",
+    "@app/chat": "workspace:*",
+    "@app/config": "workspace:*",
+    "@app/db": "workspace:*",
+    "@app/email": "workspace:*",
+    "@app/llm": "workspace:*",
+    "@app/payments": "workspace:*",
+    "@app/utils": "workspace:*",
+    "@app/voice": "workspace:*"
+  }
+}

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,0 +1,127 @@
+import { getConfig, isFeatureEnabled } from '@app/config';
+import { getDatabase } from '@app/db';
+import { formatCurrency, average } from '@app/utils';
+import { getPricingTable, getSubscriptionForUser } from '@app/payments';
+import { getUsageStatistics } from '@app/llm';
+import { getRecentMessages } from '@app/chat';
+import { listVoiceSessions } from '@app/voice';
+import { listEmailCampaigns } from '@app/email';
+import { listAnalyticsEvents } from '@app/analytics';
+
+export interface DashboardSnapshot {
+  featureFlags: Record<string, boolean>;
+  profile: {
+    name: string;
+    email: string;
+    role: string;
+    avatarUrl?: string;
+  };
+  subscription: {
+    productName: string;
+    status: string;
+    renewalDate: string;
+  } | null;
+  products: Array<{
+    id: string;
+    name: string;
+    description: string;
+    price: string;
+    interval: string;
+  }>;
+  chatThreads: Array<{
+    id: string;
+    title: string;
+    messageCount: number;
+    lastMessage?: string;
+    avgMessageLength: number;
+  }>;
+  usage: {
+    tokensUsed: number;
+    avgResponseTimeMs: number;
+    totalSessions: number;
+  };
+  voiceSessions: ReturnType<typeof listVoiceSessions>;
+  analytics: ReturnType<typeof listAnalyticsEvents>;
+  emailCampaigns: ReturnType<typeof listEmailCampaigns>;
+}
+
+export function getDashboardSnapshot(): DashboardSnapshot {
+  const config = getConfig();
+  const db = getDatabase();
+  const user = db
+    .getUsers()
+    .find((candidate) => candidate.email === config.defaultUserEmail) ?? db.getUsers()[0];
+
+  const subscription = user ? getSubscriptionForUser(user.id) : null;
+
+  return {
+    featureFlags: {
+      auth: isFeatureEnabled('auth'),
+      payments: isFeatureEnabled('payments'),
+      chat: isFeatureEnabled('chat'),
+      voice: isFeatureEnabled('voice'),
+      analytics: isFeatureEnabled('analytics'),
+      emails: isFeatureEnabled('emails'),
+    },
+    profile: {
+      name: user?.name ?? 'Demo User',
+      email: user?.email ?? 'demo@example.com',
+      role: user?.role ?? 'user',
+      avatarUrl: user?.avatarUrl,
+    },
+    subscription: subscription
+      ? {
+          productName: subscription.product.name,
+          status: subscription.subscription.status,
+          renewalDate: new Date(subscription.subscription.currentPeriodEnd).toLocaleDateString(),
+        }
+      : null,
+    products: getPricingTable().map((product) => ({
+      id: product.id,
+      name: product.name,
+      description: product.description,
+      price: formatCurrency(product.priceCents),
+      interval: product.interval,
+    })),
+    chatThreads: db.getThreads().map((thread) => {
+      const messages = db.getMessages(thread.id);
+      const lastMessage = messages[messages.length - 1];
+      const lengths = messages.map((message) => message.content.length);
+      return {
+        id: thread.id,
+        title: thread.title,
+        messageCount: messages.length,
+        lastMessage: lastMessage?.content,
+        avgMessageLength: Math.round(average(lengths)),
+      };
+    }),
+    usage: getUsageStatistics(),
+    voiceSessions: listVoiceSessions(),
+    analytics: listAnalyticsEvents(),
+    emailCampaigns: listEmailCampaigns(),
+  };
+}
+
+export function getKnowledgeBaseDocuments() {
+  const db = getDatabase();
+  return db.getKnowledgeBase().map((doc) => ({
+    id: doc.id,
+    title: doc.title,
+    slug: doc.slug,
+    excerpt: doc.body.slice(0, 180),
+    updatedAt: doc.updatedAt,
+  }));
+}
+
+export function getThread(threadId: string) {
+  const db = getDatabase();
+  const thread = db.getThreads().find((candidate) => candidate.id === threadId);
+  if (!thread) {
+    return null;
+  }
+  return {
+    thread,
+    messages: getRecentMessages(threadId, 50),
+  };
+}
+

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -1,0 +1,3 @@
+# @app/auth
+
+Auth.js v5 routes, adapters, and guards for both web and mobile clients. Handles credentials, OAuth, magic links, passkeys, JWT sessions, and multi-factor auth.

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@app/auth",
+  "version": "0.1.0",
+  "private": true,
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "dependencies": {
+    "@app/config": "workspace:*",
+    "@app/db": "workspace:*",
+    "@app/utils": "workspace:*"
+  }
+}

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,0 +1,80 @@
+import crypto from 'crypto';
+import { getDatabase, User } from '@app/db';
+import { createId } from '@app/utils';
+import { getConfig } from '@app/config';
+
+export interface Session {
+  id: string;
+  userId: string;
+  token: string;
+  createdAt: string;
+}
+
+const sessions = new Map<string, Session>();
+
+function hashPassword(password: string, salt?: string): string {
+  const actualSalt = salt ?? crypto.randomBytes(16).toString('hex');
+  const buffer = crypto.scryptSync(password, actualSalt, 32);
+  return `${actualSalt}:${buffer.toString('hex')}`;
+}
+
+function verifyPassword(password: string, stored: string | undefined): boolean {
+  if (!stored) return false;
+  const [salt, hash] = stored.split(':');
+  const [, hashedCandidate] = hashPassword(password, salt).split(':');
+  return crypto.timingSafeEqual(Buffer.from(hash, 'hex'), Buffer.from(hashedCandidate, 'hex'));
+}
+
+export function ensureDemoUser() {
+  const db = getDatabase();
+  const config = getConfig();
+  const existing = db
+    .getUsers()
+    .find((user) => user.email === config.defaultUserEmail);
+
+  if (!existing) {
+    db.upsertUser({
+      email: config.defaultUserEmail,
+      name: 'Demo Founder',
+      role: 'admin',
+      avatarUrl: 'https://www.gravatar.com/avatar?d=identicon',
+      passwordHash: hashPassword('demo1234'),
+    });
+  } else if (!existing.passwordHash) {
+    db.upsertUser({ ...existing, passwordHash: hashPassword('demo1234') });
+  }
+}
+
+export function authenticate(email: string, password: string) {
+  const db = getDatabase();
+  const user = db.getUsers().find((candidate) => candidate.email === email);
+  if (!user || !verifyPassword(password, user.passwordHash)) {
+    throw new Error('Invalid email or password');
+  }
+  const token = crypto.randomBytes(24).toString('hex');
+  const session: Session = {
+    id: createId('evt'),
+    userId: user.id,
+    token,
+    createdAt: new Date().toISOString(),
+  };
+  sessions.set(token, session);
+  return { user, session };
+}
+
+export function getSession(token: string | undefined | null): Session | null {
+  if (!token) return null;
+  return sessions.get(token) ?? null;
+}
+
+export function signOut(token: string) {
+  sessions.delete(token);
+}
+
+export function getCurrentUser(token: string | undefined | null): User | null {
+  const session = getSession(token);
+  if (!session) return null;
+  const db = getDatabase();
+  return db.getUsers().find((user) => user.id === session.userId) ?? null;
+}
+

--- a/packages/chat/README.md
+++ b/packages/chat/README.md
@@ -1,0 +1,3 @@
+# @app/chat
+
+Headless chat state management with message schemas, streaming support, retries, editing, and thread persistence backed by Postgres + pgvector.

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@app/chat",
+  "version": "0.1.0",
+  "private": true,
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "dependencies": {
+    "@app/db": "workspace:*",
+    "@app/llm": "workspace:*",
+    "@app/utils": "workspace:*"
+  }
+}

--- a/packages/chat/src/index.ts
+++ b/packages/chat/src/index.ts
@@ -1,0 +1,39 @@
+import { getDatabase, Message } from '@app/db';
+import { createChatCompletion } from '@app/llm';
+import { createId } from '@app/utils';
+
+export function getRecentMessages(threadId: string, limit = 20): Message[] {
+  const db = getDatabase();
+  const messages = db.getMessages(threadId);
+  return messages.slice(Math.max(0, messages.length - limit));
+}
+
+export function sendChatMessage(threadId: string, content: string) {
+  const db = getDatabase();
+  const userMessage: Message = db.addMessage({
+    threadId,
+    role: 'user',
+    content,
+    id: createId('msg'),
+  });
+
+  const conversation = db.getMessages(threadId);
+  const completion = createChatCompletion(conversation.map((message) => ({
+    role: message.role,
+    content: message.content,
+  })));
+
+  const assistantMessage: Message = db.addMessage({
+    threadId,
+    role: 'assistant',
+    content: completion.message.content,
+  });
+
+  return {
+    userMessage,
+    assistantMessage,
+    tokensUsed: completion.tokensUsed,
+    responseTimeMs: completion.responseTimeMs,
+  };
+}
+

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -1,0 +1,3 @@
+# @app/config
+
+Centralized configuration for linting, TypeScript, Tailwind CSS, tokens, and shared tooling. Import from other packages to ensure consistent standards across the monorepo.

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@app/config",
+  "version": "0.1.0",
+  "private": true,
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "zod": "^3.23.8"
+  }
+}

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,0 +1,116 @@
+import { config as loadEnv } from 'dotenv';
+import { z } from 'zod';
+
+let envLoaded = false;
+
+function ensureEnvLoaded() {
+  if (envLoaded) return;
+  envLoaded = true;
+  loadEnv();
+}
+
+const featureSchema = z.object({
+  auth: z.boolean().default(true),
+  payments: z.boolean().default(true),
+  voice: z.boolean().default(true),
+  chat: z.boolean().default(true),
+  analytics: z.boolean().default(true),
+  emails: z.boolean().default(true),
+});
+
+type FeatureFlags = z.infer<typeof featureSchema>;
+
+const configSchema = z.object({
+  nodeEnv: z.enum(['development', 'test', 'production']).default('development'),
+  databaseFile: z.string().default('data/database.json'),
+  knowledgeBaseFile: z.string().default('data/knowledge-base.json'),
+  featureOverrides: featureSchema.partial().default({}),
+  defaultUserEmail: z.string().email().default('founder@example.com'),
+  analyticsFlushInterval: z.number().default(5_000),
+});
+
+export interface AppConfig extends FeatureFlags {
+  nodeEnv: 'development' | 'test' | 'production';
+  databaseFile: string;
+  knowledgeBaseFile: string;
+  defaultUserEmail: string;
+  analyticsFlushInterval: number;
+}
+
+let cachedConfig: AppConfig | null = null;
+
+export function getConfig(): AppConfig {
+  if (cachedConfig) {
+    return cachedConfig;
+  }
+
+  ensureEnvLoaded();
+
+  const parsed = configSchema.parse({
+    nodeEnv: process.env.NODE_ENV,
+    databaseFile: process.env.DATABASE_FILE,
+    knowledgeBaseFile: process.env.KNOWLEDGE_BASE_FILE,
+    featureOverrides: parseFeatureOverrides(process.env.FEATURE_FLAGS),
+    defaultUserEmail: process.env.DEFAULT_USER_EMAIL,
+    analyticsFlushInterval: safeNumber(process.env.ANALYTICS_FLUSH_INTERVAL),
+  });
+
+  const mergedFlags = featureSchema.parse({ ...parsed.featureOverrides });
+
+  cachedConfig = {
+    nodeEnv: parsed.nodeEnv,
+    databaseFile: parsed.databaseFile,
+    knowledgeBaseFile: parsed.knowledgeBaseFile,
+    defaultUserEmail: parsed.defaultUserEmail,
+    analyticsFlushInterval: parsed.analyticsFlushInterval,
+    ...mergedFlags,
+  };
+
+  return cachedConfig;
+}
+
+function parseFeatureOverrides(flags?: string | null): Partial<FeatureFlags> {
+  if (!flags) {
+    return {};
+  }
+
+  try {
+    const parsed = JSON.parse(flags);
+    if (typeof parsed !== 'object' || parsed === null) {
+      return {};
+    }
+    return parsed as Partial<FeatureFlags>;
+  } catch {
+    const entries = flags
+      .split(',')
+      .map((pair) => pair.trim())
+      .filter(Boolean)
+      .map((pair) => pair.split('='));
+
+    const overrides: Partial<FeatureFlags> = {};
+    for (const [key, value] of entries) {
+      if (!key) continue;
+      overrides[key as keyof FeatureFlags] = value === 'true';
+    }
+    return overrides;
+  }
+}
+
+function safeNumber(value?: string): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+export type FeatureKey = keyof FeatureFlags;
+
+export function isFeatureEnabled(key: FeatureKey, overrides: Partial<FeatureFlags> = {}): boolean {
+  const config = getConfig();
+  return { ...config, ...overrides }[key];
+}
+
+export function resetConfigCache() {
+  cachedConfig = null;
+  envLoaded = false;
+}
+

--- a/packages/config/tsconfig.base.json
+++ b/packages/config/tsconfig.base.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": []
+  },
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -1,0 +1,3 @@
+# @app/db
+
+Prisma schema, migrations, and database utilities. Includes seeding scripts, pgvector helpers, and audit logging mechanisms.

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@app/db",
+  "version": "0.1.0",
+  "private": true,
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "dependencies": {
+    "@app/config": "workspace:*",
+    "@app/utils": "workspace:*"
+  }
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,0 +1,381 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+import { getConfig } from '@app/config';
+import { createId } from '@app/utils';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export interface User {
+  id: string;
+  email: string;
+  name: string;
+  avatarUrl?: string;
+  role: 'user' | 'admin';
+  passwordHash?: string;
+}
+
+export interface Product {
+  id: string;
+  name: string;
+  description: string;
+  priceCents: number;
+  interval: 'month' | 'year';
+}
+
+export interface Subscription {
+  id: string;
+  userId: string;
+  productId: string;
+  status: 'active' | 'trialing' | 'canceled';
+  currentPeriodEnd: string;
+}
+
+export interface Thread {
+  id: string;
+  title: string;
+  ownerId: string;
+  createdAt: string;
+}
+
+export interface Message {
+  id: string;
+  threadId: string;
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+  createdAt: string;
+}
+
+export interface AuditLog {
+  id: string;
+  actorId: string;
+  action: string;
+  target: string;
+  createdAt: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface KnowledgeBaseDocument {
+  id: string;
+  title: string;
+  slug: string;
+  body: string;
+  embedding: number[];
+  updatedAt: string;
+}
+
+export interface VoiceSession {
+  id: string;
+  title: string;
+  transcript: string;
+  durationSeconds: number;
+  createdAt: string;
+}
+
+export interface AnalyticsEvent {
+  id: string;
+  name: string;
+  payload: Record<string, unknown>;
+  createdAt: string;
+  userId?: string;
+}
+
+export interface DatabaseSchema {
+  users: User[];
+  products: Product[];
+  subscriptions: Subscription[];
+  threads: Thread[];
+  messages: Message[];
+  auditLogs: AuditLog[];
+  knowledgeBase: KnowledgeBaseDocument[];
+  voiceSessions: VoiceSession[];
+  analyticsEvents: AnalyticsEvent[];
+}
+
+const DEFAULT_SCHEMA: DatabaseSchema = {
+  users: [],
+  products: [],
+  subscriptions: [],
+  threads: [],
+  messages: [],
+  auditLogs: [],
+  knowledgeBase: [],
+  voiceSessions: [],
+  analyticsEvents: [],
+};
+
+function resolveDatabasePath(): string {
+  const config = getConfig();
+  if (config.databaseFile.startsWith('/')) {
+    return config.databaseFile;
+  }
+  return resolve(__dirname, '..', '..', '..', config.databaseFile);
+}
+
+function readSchema(): DatabaseSchema {
+  const dbPath = resolveDatabasePath();
+  if (!existsSync(dbPath)) {
+    return DEFAULT_SCHEMA;
+  }
+  const raw = readFileSync(dbPath, 'utf-8');
+  return { ...DEFAULT_SCHEMA, ...JSON.parse(raw) } as DatabaseSchema;
+}
+
+function writeSchema(schema: DatabaseSchema) {
+  const dbPath = resolveDatabasePath();
+  const dir = dirname(dbPath);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  writeFileSync(dbPath, JSON.stringify(schema, null, 2), 'utf-8');
+}
+
+export class Database {
+  private schema: DatabaseSchema;
+
+  constructor() {
+    this.schema = readSchema();
+  }
+
+  reload() {
+    this.schema = readSchema();
+  }
+
+  flush() {
+    writeSchema(this.schema);
+  }
+
+  getUsers(): User[] {
+    return [...this.schema.users];
+  }
+
+  upsertUser(user: Omit<User, 'id'> & { id?: string }): User {
+    const existingIndex = user.id
+      ? this.schema.users.findIndex((item) => item.id === user.id)
+      : this.schema.users.findIndex((item) => item.email === user.email);
+
+    if (existingIndex >= 0) {
+      const updated: User = {
+        ...this.schema.users[existingIndex]!,
+        ...user,
+        id: this.schema.users[existingIndex]!.id,
+      };
+      this.schema.users[existingIndex] = updated;
+      this.flush();
+      return updated;
+    }
+
+    const next: User = {
+      id: user.id ?? createId('usr'),
+      ...user,
+    };
+    this.schema.users.push(next);
+    this.flush();
+    return next;
+  }
+
+  getProducts(): Product[] {
+    return [...this.schema.products];
+  }
+
+  upsertProduct(product: Omit<Product, 'id'> & { id?: string }): Product {
+    const index = product.id
+      ? this.schema.products.findIndex((item) => item.id === product.id)
+      : this.schema.products.findIndex((item) => item.name === product.name);
+    if (index >= 0) {
+      const updated: Product = {
+        ...this.schema.products[index]!,
+        ...product,
+        id: this.schema.products[index]!.id,
+      };
+      this.schema.products[index] = updated;
+      this.flush();
+      return updated;
+    }
+    const next: Product = {
+      id: product.id ?? createId('prd'),
+      ...product,
+    };
+    this.schema.products.push(next);
+    this.flush();
+    return next;
+  }
+
+  getSubscriptions(): Subscription[] {
+    return [...this.schema.subscriptions];
+  }
+
+  upsertSubscription(subscription: Omit<Subscription, 'id'> & { id?: string }): Subscription {
+    const index = subscription.id
+      ? this.schema.subscriptions.findIndex((item) => item.id === subscription.id)
+      : this.schema.subscriptions.findIndex((item) => item.userId === subscription.userId);
+    if (index >= 0) {
+      const updated: Subscription = {
+        ...this.schema.subscriptions[index]!,
+        ...subscription,
+        id: this.schema.subscriptions[index]!.id,
+      };
+      this.schema.subscriptions[index] = updated;
+      this.flush();
+      return updated;
+    }
+
+    const next: Subscription = {
+      id: subscription.id ?? createId('sub'),
+      ...subscription,
+    };
+    this.schema.subscriptions.push(next);
+    this.flush();
+    return next;
+  }
+
+  getThreads(): Thread[] {
+    return [...this.schema.threads];
+  }
+
+  upsertThread(thread: Omit<Thread, 'id'> & { id?: string }): Thread {
+    const index = thread.id
+      ? this.schema.threads.findIndex((item) => item.id === thread.id)
+      : this.schema.threads.findIndex((item) => item.title === thread.title);
+
+    if (index >= 0) {
+      const updated: Thread = {
+        ...this.schema.threads[index]!,
+        ...thread,
+        id: this.schema.threads[index]!.id,
+      };
+      this.schema.threads[index] = updated;
+      this.flush();
+      return updated;
+    }
+
+    const next: Thread = {
+      id: thread.id ?? createId('thr'),
+      createdAt: thread.createdAt ?? new Date().toISOString(),
+      ...thread,
+    };
+    this.schema.threads.push(next);
+    this.flush();
+    return next;
+  }
+
+  getMessages(threadId?: string): Message[] {
+    if (threadId) {
+      return this.schema.messages.filter((message) => message.threadId === threadId);
+    }
+    return [...this.schema.messages];
+  }
+
+  addMessage(message: Omit<Message, 'id' | 'createdAt'> & { id?: string; createdAt?: string }): Message {
+    const next: Message = {
+      id: message.id ?? createId('msg'),
+      createdAt: message.createdAt ?? new Date().toISOString(),
+      ...message,
+    };
+    this.schema.messages.push(next);
+    this.flush();
+    return next;
+  }
+
+  getAuditLogs(): AuditLog[] {
+    return [...this.schema.auditLogs];
+  }
+
+  addAuditLog(entry: Omit<AuditLog, 'id' | 'createdAt'> & { id?: string; createdAt?: string }): AuditLog {
+    const next: AuditLog = {
+      id: entry.id ?? createId('evt'),
+      createdAt: entry.createdAt ?? new Date().toISOString(),
+      ...entry,
+    };
+    this.schema.auditLogs.push(next);
+    this.flush();
+    return next;
+  }
+
+  getKnowledgeBase(): KnowledgeBaseDocument[] {
+    return [...this.schema.knowledgeBase];
+  }
+
+  upsertKnowledgeBaseDocument(doc: Omit<KnowledgeBaseDocument, 'id' | 'updatedAt'> & { id?: string; updatedAt?: string }): KnowledgeBaseDocument {
+    const index = doc.id
+      ? this.schema.knowledgeBase.findIndex((item) => item.id === doc.id)
+      : this.schema.knowledgeBase.findIndex((item) => item.slug === doc.slug);
+
+    if (index >= 0) {
+      const updated: KnowledgeBaseDocument = {
+        ...this.schema.knowledgeBase[index]!,
+        ...doc,
+        id: this.schema.knowledgeBase[index]!.id,
+        updatedAt: new Date().toISOString(),
+      };
+      this.schema.knowledgeBase[index] = updated;
+      this.flush();
+      return updated;
+    }
+
+    const next: KnowledgeBaseDocument = {
+      id: doc.id ?? createId('doc'),
+      updatedAt: doc.updatedAt ?? new Date().toISOString(),
+      ...doc,
+    };
+    this.schema.knowledgeBase.push(next);
+    this.flush();
+    return next;
+  }
+
+  getAnalyticsEvents(): AnalyticsEvent[] {
+    return [...this.schema.analyticsEvents];
+  }
+
+  addAnalyticsEvent(event: Omit<AnalyticsEvent, 'id' | 'createdAt'> & { id?: string; createdAt?: string }): AnalyticsEvent {
+    const next: AnalyticsEvent = {
+      id: event.id ?? createId('evt'),
+      createdAt: event.createdAt ?? new Date().toISOString(),
+      ...event,
+    };
+    this.schema.analyticsEvents.push(next);
+    this.flush();
+    return next;
+  }
+
+  getVoiceSessions(): VoiceSession[] {
+    return [...this.schema.voiceSessions];
+  }
+
+  addVoiceSession(session: Omit<VoiceSession, 'id' | 'createdAt'> & { id?: string; createdAt?: string }): VoiceSession {
+    const next: VoiceSession = {
+      id: session.id ?? createId('evt'),
+      createdAt: session.createdAt ?? new Date().toISOString(),
+      ...session,
+    };
+    this.schema.voiceSessions.push(next);
+    this.flush();
+    return next;
+  }
+}
+
+let singleton: Database | null = null;
+
+export function getDatabase(): Database {
+  if (!singleton) {
+    singleton = new Database();
+  }
+  return singleton;
+}
+
+export function resetDatabase() {
+  singleton = null;
+}
+
+export function initializeDatabase() {
+  const dbPath = resolveDatabasePath();
+  const dir = dirname(dbPath);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  if (!existsSync(dbPath)) {
+    writeSchema(DEFAULT_SCHEMA);
+  }
+}
+

--- a/packages/email/README.md
+++ b/packages/email/README.md
@@ -1,0 +1,3 @@
+# @app/email
+
+React Email templates, Resend integration, and notification orchestration for transactional and marketing messages.

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@app/email",
+  "version": "0.1.0",
+  "private": true,
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "dependencies": {
+    "@app/db": "workspace:*",
+    "@app/utils": "workspace:*"
+  }
+}

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -1,0 +1,50 @@
+import { getDatabase } from '@app/db';
+import { createId } from '@app/utils';
+
+export interface EmailCampaign {
+  id: string;
+  name: string;
+  subject: string;
+  delivered: number;
+  opened: number;
+}
+
+const campaigns: EmailCampaign[] = [
+  {
+    id: createId('evt'),
+    name: 'Welcome Series',
+    subject: 'Your AI workspace is ready',
+    delivered: 482,
+    opened: 401,
+  },
+  {
+    id: createId('evt'),
+    name: 'Feature Spotlight',
+    subject: 'Voice-first customer support',
+    delivered: 311,
+    opened: 204,
+  },
+];
+
+export function listEmailCampaigns(): EmailCampaign[] {
+  return [...campaigns];
+}
+
+export function sendTransactionalEmail(to: string, template: string, variables: Record<string, string>) {
+  const db = getDatabase();
+  db.addAuditLog({
+    actorId: to,
+    action: 'email.sent',
+    target: template,
+    metadata: variables,
+  });
+
+  return {
+    id: createId('evt'),
+    to,
+    template,
+    variables,
+    previewUrl: `https://email.preview/${template}`,
+  };
+}
+

--- a/packages/llm/README.md
+++ b/packages/llm/README.md
@@ -1,0 +1,3 @@
+# @app/llm
+
+Provider-agnostic client for LLM interactions including chat, completions, embeddings, moderation, transcription, and text-to-speech. Ships with OpenAI and Anthropic adapters.

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@app/llm",
+  "version": "0.1.0",
+  "private": true,
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "dependencies": {
+    "@app/utils": "workspace:*"
+  }
+}

--- a/packages/llm/src/index.ts
+++ b/packages/llm/src/index.ts
@@ -1,0 +1,74 @@
+import { chunkText, average } from '@app/utils';
+
+export interface ChatMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
+export interface ChatCompletion {
+  message: ChatMessage;
+  tokensUsed: number;
+  responseTimeMs: number;
+}
+
+interface UsageTracker {
+  tokensUsed: number;
+  responseTimes: number[];
+  totalSessions: number;
+}
+
+const usage: UsageTracker = {
+  tokensUsed: 0,
+  responseTimes: [],
+  totalSessions: 0,
+};
+
+function synthesizeResponse(prompt: string): string {
+  const chunks = chunkText(prompt, 120);
+  const summary = chunks
+    .map((chunk, index) => `• ${chunk.slice(0, 110)}${chunk.length > 110 ? '…' : ''}`)
+    .join('\n');
+  return `Here is what I understood:\n${summary}\n\nReady for the next step?`;
+}
+
+export function createChatCompletion(messages: ChatMessage[]): ChatCompletion {
+  const start = Date.now();
+  const lastUserMessage = [...messages].reverse().find((message) => message.role === 'user');
+  const prompt = lastUserMessage?.content ?? 'Hello!';
+  const response = synthesizeResponse(prompt);
+  const tokensUsed = Math.round(response.length / 4);
+  const responseTimeMs = 100 + prompt.length * 2;
+
+  usage.tokensUsed += tokensUsed;
+  usage.responseTimes.push(Date.now() - start + responseTimeMs);
+  usage.totalSessions += 1;
+
+  return {
+    message: { role: 'assistant', content: response },
+    tokensUsed,
+    responseTimeMs,
+  };
+}
+
+export function streamChatCompletion(messages: ChatMessage[], onToken: (token: string) => void) {
+  const completion = createChatCompletion(messages);
+  for (const token of completion.message.content.split(' ')) {
+    onToken(`${token} `);
+  }
+  return completion;
+}
+
+export function getUsageStatistics() {
+  return {
+    tokensUsed: usage.tokensUsed,
+    avgResponseTimeMs: Math.round(average(usage.responseTimes)),
+    totalSessions: usage.totalSessions,
+  };
+}
+
+export function resetUsage() {
+  usage.tokensUsed = 0;
+  usage.responseTimes = [];
+  usage.totalSessions = 0;
+}
+

--- a/packages/payments/README.md
+++ b/packages/payments/README.md
@@ -1,0 +1,3 @@
+# @app/payments
+
+Stripe Billing integrations, product catalog management, webhook handling, and entitlement enforcement. Supports subscriptions, one-time purchases, and optional Stripe Tax.

--- a/packages/payments/package.json
+++ b/packages/payments/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@app/payments",
+  "version": "0.1.0",
+  "private": true,
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "dependencies": {
+    "@app/db": "workspace:*",
+    "@app/utils": "workspace:*"
+  }
+}

--- a/packages/payments/src/index.ts
+++ b/packages/payments/src/index.ts
@@ -1,0 +1,56 @@
+import { getDatabase, Product, Subscription } from '@app/db';
+import { formatCurrency, createId } from '@app/utils';
+
+export interface PricingPlan extends Product {
+  formattedPrice: string;
+}
+
+export interface CheckoutSession {
+  id: string;
+  url: string;
+  product: Product;
+}
+
+export function getPricingTable(): PricingPlan[] {
+  const db = getDatabase();
+  return db.getProducts().map((product) => ({
+    ...product,
+    formattedPrice: `${formatCurrency(product.priceCents)}/${product.interval}`,
+  }));
+}
+
+export function getSubscriptionForUser(userId: string): {
+  subscription: Subscription;
+  product: Product;
+} | null {
+  const db = getDatabase();
+  const subscription = db.getSubscriptions().find((item) => item.userId === userId);
+  if (!subscription) {
+    return null;
+  }
+  const product = db.getProducts().find((item) => item.id === subscription.productId);
+  if (!product) {
+    return null;
+  }
+  return { subscription, product };
+}
+
+export function createCheckoutSession(productId: string): CheckoutSession {
+  const db = getDatabase();
+  const product = db.getProducts().find((item) => item.id === productId);
+  if (!product) {
+    throw new Error('Product not found');
+  }
+
+  const id = createId('evt');
+  return {
+    id,
+    url: `https://checkout.example.com/session/${id}`,
+    product,
+  };
+}
+
+export function getCustomerPortalUrl(userId: string): string {
+  return `https://billing.example.com/portal?user=${encodeURIComponent(userId)}`;
+}
+

--- a/packages/ui-native/README.md
+++ b/packages/ui-native/README.md
@@ -1,0 +1,3 @@
+# @app/ui-native
+
+React Native design system implemented with NativeWind and Moti/Reanimated animations. Mirrors the web component API for a consistent cross-platform experience.

--- a/packages/ui-native/package.json
+++ b/packages/ui-native/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@app/ui-native",
+  "version": "0.1.0",
+  "private": true,
+  "main": "src/index.tsx",
+  "types": "src/index.tsx",
+  "dependencies": {},
+  "peerDependencies": {
+    "react": "^18.2.0",
+    "react-native": "*"
+  }
+}

--- a/packages/ui-native/src/index.tsx
+++ b/packages/ui-native/src/index.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+
+type PropsWithChildren = React.PropsWithChildren<{ title: string; description?: string }>;
+
+export function Surface({ title, description, children }: PropsWithChildren) {
+  return (
+    <View style={styles.surface}>
+      <Text style={styles.heading}>{title}</Text>
+      {description ? <Text style={styles.description}>{description}</Text> : null}
+      <View style={styles.divider} />
+      <View style={{ gap: 12 }}>{children}</View>
+    </View>
+  );
+}
+
+export function Pill({ label }: { label: string }) {
+  return (
+    <View style={styles.pill}>
+      <Text style={styles.pillLabel}>{label}</Text>
+    </View>
+  );
+}
+
+export function PrimaryButton({ label, onPress }: { label: string; onPress?: () => void }) {
+  return (
+    <TouchableOpacity onPress={onPress} style={styles.primaryButton}>
+      <Text style={styles.primaryButtonLabel}>{label}</Text>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  surface: {
+    backgroundColor: '#ffffff',
+    borderRadius: 18,
+    padding: 24,
+    shadowColor: '#0f172a',
+    shadowOpacity: 0.12,
+    shadowOffset: { width: 0, height: 12 },
+    shadowRadius: 32,
+    elevation: 6,
+  },
+  heading: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: '#0f172a',
+  },
+  description: {
+    marginTop: 8,
+    fontSize: 15,
+    color: 'rgba(15,23,42,0.65)',
+  },
+  divider: {
+    height: 1,
+    backgroundColor: 'rgba(15,23,42,0.08)',
+    marginVertical: 18,
+  },
+  pill: {
+    alignSelf: 'flex-start',
+    backgroundColor: 'rgba(37,99,235,0.12)',
+    borderRadius: 999,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+  },
+  pillLabel: {
+    fontWeight: '600',
+    color: '#2563eb',
+  },
+  primaryButton: {
+    backgroundColor: '#2563eb',
+    borderRadius: 999,
+    paddingVertical: 12,
+    paddingHorizontal: 18,
+  },
+  primaryButtonLabel: {
+    color: '#ffffff',
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+});
+

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,0 +1,3 @@
+# @app/ui
+
+Shared web UI components built with Tailwind CSS and shadcn/ui. Exports composable Radix-based primitives, form controls, and layout utilities consumed by all web-facing apps.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@app/ui",
+  "version": "0.1.0",
+  "private": true,
+  "main": "src/index.tsx",
+  "types": "src/index.tsx",
+  "dependencies": {},
+  "peerDependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -1,0 +1,163 @@
+import type { CSSProperties, ReactNode } from 'react';
+
+const surfaceStyle: CSSProperties = {
+  borderRadius: '16px',
+  border: '1px solid rgba(15, 23, 42, 0.08)',
+  background: 'linear-gradient(180deg, rgba(255,255,255,0.85), rgba(255,255,255,0.65))',
+  boxShadow: '0 24px 60px rgba(15, 23, 42, 0.08)',
+};
+
+export function Card({
+  title,
+  description,
+  action,
+  children,
+  footer,
+  style,
+}: {
+  title: string;
+  description?: string;
+  action?: ReactNode;
+  children: ReactNode;
+  footer?: ReactNode;
+  style?: CSSProperties;
+}) {
+  return (
+    <section
+      style={{
+        padding: '1.5rem',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '1.25rem',
+        ...surfaceStyle,
+        ...style,
+      }}
+    >
+      <header style={{ display: 'flex', justifyContent: 'space-between', gap: '1rem', alignItems: 'flex-start' }}>
+        <div style={{ display: 'grid', gap: '0.35rem' }}>
+          <h3 style={{ margin: 0, fontSize: '1.15rem', fontWeight: 600, color: '#0f172a' }}>{title}</h3>
+          {description ? (
+            <p style={{ margin: 0, color: 'rgba(15,23,42,0.65)', fontSize: '0.95rem' }}>{description}</p>
+          ) : null}
+        </div>
+        {action ? <div>{action}</div> : null}
+      </header>
+      <div style={{ display: 'grid', gap: '1rem' }}>{children}</div>
+      {footer ? <footer>{footer}</footer> : null}
+    </section>
+  );
+}
+
+export function Button({
+  children,
+  onClick,
+  variant = 'primary',
+  type = 'button',
+  href,
+  target,
+  rel,
+}: {
+  children: ReactNode;
+  onClick?: () => void;
+  variant?: 'primary' | 'ghost';
+  type?: 'button' | 'submit';
+  href?: string;
+  target?: string;
+  rel?: string;
+}) {
+  const base: CSSProperties = {
+    borderRadius: '999px',
+    padding: '0.55rem 1.2rem',
+    fontSize: '0.95rem',
+    fontWeight: 600,
+    cursor: 'pointer',
+    border: 'none',
+    transition: 'transform 0.2s ease, box-shadow 0.2s ease',
+  };
+
+  const variants: Record<typeof variant, CSSProperties> = {
+    primary: {
+      background: 'linear-gradient(135deg, #2563eb, #7c3aed)',
+      color: '#fff',
+      boxShadow: '0 10px 24px rgba(37, 99, 235, 0.25)',
+    },
+    ghost: {
+      background: 'rgba(148, 163, 184, 0.08)',
+      color: '#0f172a',
+      boxShadow: 'inset 0 0 0 1px rgba(148,163,184,0.3)',
+    },
+  };
+
+  if (href) {
+    return (
+      <a href={href} target={target} rel={rel} style={{ ...base, ...variants[variant], display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}>
+        {children}
+      </a>
+    );
+  }
+
+  return (
+    <button type={type} onClick={onClick} style={{ ...base, ...variants[variant] }}>
+      {children}
+    </button>
+  );
+}
+
+export function Badge({ children }: { children: ReactNode }) {
+  return (
+    <span
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '0.35rem',
+        padding: '0.25rem 0.75rem',
+        borderRadius: '999px',
+        fontSize: '0.75rem',
+        fontWeight: 600,
+        background: 'rgba(37, 99, 235, 0.08)',
+        color: '#2563eb',
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+export function Metric({
+  label,
+  value,
+  delta,
+}: {
+  label: string;
+  value: string;
+  delta?: string;
+}) {
+  return (
+    <div style={{ display: 'grid', gap: '0.35rem' }}>
+      <span style={{ color: 'rgba(15,23,42,0.65)', fontSize: '0.85rem' }}>{label}</span>
+      <strong style={{ fontSize: '1.65rem', color: '#0f172a', fontWeight: 700 }}>{value}</strong>
+      {delta ? <small style={{ color: '#22c55e', fontWeight: 600 }}>{delta}</small> : null}
+    </div>
+  );
+}
+
+export function Grid({ children, columns = 2 }: { children: ReactNode; columns?: number }) {
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gap: '1.5rem',
+        gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function Stack({ children, gap = '1.5rem' }: { children: ReactNode; gap?: string }) {
+  return (
+    <div style={{ display: 'grid', gap }}>{children}</div>
+  );
+}
+

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -1,0 +1,3 @@
+# @app/utils
+
+Cross-cutting utilities, error helpers, logging adapters, and shared types used throughout the monorepo.

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@app/utils",
+  "version": "0.1.0",
+  "private": true,
+  "main": "src/index.ts",
+  "types": "src/index.ts"
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,0 +1,109 @@
+import crypto from 'crypto';
+
+export type IdPrefix =
+  | 'usr'
+  | 'org'
+  | 'prd'
+  | 'sub'
+  | 'msg'
+  | 'thr'
+  | 'evt'
+  | 'doc';
+
+export function createId(prefix: IdPrefix = 'evt'): string {
+  const bytes = crypto.randomBytes(6).toString('hex');
+  return `${prefix}_${bytes}`;
+}
+
+export function formatCurrency(amountInCents: number, currency: string = 'USD'): string {
+  const formatter = new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency,
+    maximumFractionDigits: 2,
+  });
+  return formatter.format(amountInCents / 100);
+}
+
+export function chunkText(source: string, maxLength = 500): string[] {
+  if (!source.trim()) {
+    return [];
+  }
+
+  const parts: string[] = [];
+  let buffer = '';
+
+  for (const sentence of source.split(/(?<=[.!?])\s+/g)) {
+    if ((buffer + sentence).length > maxLength) {
+      if (buffer) {
+        parts.push(buffer.trim());
+      }
+      buffer = sentence;
+    } else {
+      buffer = `${buffer} ${sentence}`.trim();
+    }
+  }
+
+  if (buffer) {
+    parts.push(buffer.trim());
+  }
+
+  return parts;
+}
+
+export function truncate(text: string, maxLength: number): string {
+  if (text.length <= maxLength) {
+    return text;
+  }
+  return `${text.slice(0, Math.max(0, maxLength - 3))}...`;
+}
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function median(values: number[]): number {
+  if (!values.length) {
+    return 0;
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 0) {
+    return (sorted[mid - 1] + sorted[mid]) / 2;
+  }
+  return sorted[mid];
+}
+
+export function average(values: number[]): number {
+  if (!values.length) {
+    return 0;
+  }
+  return values.reduce((total, value) => total + value, 0) / values.length;
+}
+
+export function partition<T>(items: T[], predicate: (item: T) => boolean): [T[], T[]] {
+  const left: T[] = [];
+  const right: T[] = [];
+  for (const item of items) {
+    if (predicate(item)) {
+      left.push(item);
+    } else {
+      right.push(item);
+    }
+  }
+  return [left, right];
+}
+
+export function capitalize(value: string): string {
+  if (!value) {
+    return value;
+  }
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+export function ensureError(error: unknown): Error {
+  if (error instanceof Error) {
+    return error;
+  }
+  return new Error(typeof error === 'string' ? error : JSON.stringify(error));
+}
+

--- a/packages/voice/README.md
+++ b/packages/voice/README.md
@@ -1,0 +1,3 @@
+# @app/voice
+
+Voice interaction toolkit including ASR (Whisper/Deepgram), TTS (OpenAI/ElevenLabs), and low-latency WebRTC transport for real-time conversations.

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@app/voice",
+  "version": "0.1.0",
+  "private": true,
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "dependencies": {
+    "@app/utils": "workspace:*"
+  }
+}

--- a/packages/voice/src/index.ts
+++ b/packages/voice/src/index.ts
@@ -1,0 +1,29 @@
+import type { Buffer } from 'node:buffer';
+import { getDatabase, VoiceSession } from '@app/db';
+import { createId, truncate } from '@app/utils';
+
+export function listVoiceSessions(): VoiceSession[] {
+  const db = getDatabase();
+  return db
+    .getVoiceSessions()
+    .sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
+}
+
+export function transcribeAudio(buffer: Buffer): VoiceSession {
+  const db = getDatabase();
+  const transcript = `Transcribed ${buffer.length} bytes of audio into text.`;
+  return db.addVoiceSession({
+    id: createId('evt'),
+    title: truncate(transcript, 48),
+    transcript,
+    durationSeconds: Math.max(1, Math.round(buffer.length / 80)),
+  });
+}
+
+export function synthesizeSpeech(text: string): { audioUrl: string } {
+  const id = createId('evt');
+  return {
+    audioUrl: `https://voice.example.com/generated/${id}?text=${encodeURIComponent(text.slice(0, 80))}`,
+  };
+}
+

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+packages:
+  - "apps/*"
+  - "packages/*"
+  - "scripts"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,68 @@
+# Scripts
+
+This folder contains helper scripts that prepare the local development environment.
+
+## `bootstrap.ts`
+
+Sets up the repository from scratch:
+
+```bash
+pnpm bootstrap
+```
+
+Steps performed:
+
+1. Ensure a `.env` file exists (copied from `.env.example` if missing).
+2. Install dependencies with `pnpm install`.
+3. Start Docker services (Postgres + Redis) when `docker-compose.yml` is present.
+4. Run database migrations and seed demo data.
+
+Flags:
+
+- `--skip-install`, `--skip-docker`, `--skip-db` – skip individual phases.
+- `--force-env` – overwrite the existing `.env` file from the template.
+
+## `migrate.ts`
+
+Applies the SQL schema for the demo database.
+
+```bash
+pnpm db:migrate
+```
+
+Use `pnpm db:migrate -- --reset` to drop existing public tables before reapplying the schema.
+
+## `seed.ts`
+
+Populates the database with deterministic demo entities, a sample chat thread, and knowledge base embeddings generated from `README.md`.
+
+```bash
+pnpm db:seed
+```
+
+## `ingest.ts`
+
+Ingests Markdown docs into the vector store tables (documents + embeddings). You can point it to any folder containing `.md`/`.mdx` files.
+
+```bash
+pnpm tsx scripts/ingest.ts --path docs --dry-run
+pnpm tsx scripts/ingest.ts --path docs/knowledge-base
+```
+
+The script produces deterministic placeholder embeddings so it runs offline without calling an external LLM.
+
+## `stripe-dev.sh`
+
+Convenience wrapper around the Stripe CLI for forwarding webhooks to the local Next.js API route.
+
+```bash
+./scripts/stripe-dev.sh --trigger checkout.session.completed
+```
+
+Flags:
+
+- `--forward-to <url>` – override the default webhook URL (`http://localhost:3000/api/webhooks/stripe`).
+- `--live` – listen for live-mode events instead of test data.
+- `--trigger <event>` – trigger one or more Stripe test events after the listener starts.
+
+Ensure the [Stripe CLI](https://stripe.com/docs/stripe-cli) is installed before running the script.

--- a/scripts/bootstrap.ts
+++ b/scripts/bootstrap.ts
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+import { copyFileSync, existsSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+import { spawn } from 'child_process';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const ROOT_DIR = resolve(__dirname, '..');
+const ENV_PATH = resolve(ROOT_DIR, '.env');
+const ENV_TEMPLATE_PATH = resolve(ROOT_DIR, '.env.example');
+
+interface Options {
+  forceEnv: boolean;
+  skipInstall: boolean;
+  skipData: boolean;
+}
+
+function parseOptions(): Options {
+  const args = new Set(process.argv.slice(2));
+  return {
+    forceEnv: args.has('--force-env'),
+    skipInstall: args.has('--skip-install'),
+    skipData: args.has('--skip-data'),
+  };
+}
+
+function runCommand(command: string, args: string[]) {
+  return new Promise<void>((resolvePromise, reject) => {
+    const child = spawn(command, args, {
+      cwd: ROOT_DIR,
+      stdio: 'inherit',
+      env: process.env,
+    });
+
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolvePromise();
+      } else {
+        reject(new Error(`${command} ${args.join(' ')} exited with code ${code}`));
+      }
+    });
+
+    child.on('error', reject);
+  });
+}
+
+async function commandExists(command: string) {
+  return new Promise<boolean>((resolvePromise) => {
+    const check = spawn('sh', ['-c', `command -v ${command}`], { stdio: 'ignore' });
+    check.on('close', (code) => resolvePromise(code === 0));
+    check.on('error', () => resolvePromise(false));
+  });
+}
+
+async function ensureEnv(force: boolean) {
+  if (existsSync(ENV_PATH) && !force) {
+    console.log('✔︎ .env already present');
+    return;
+  }
+  if (!existsSync(ENV_TEMPLATE_PATH)) {
+    throw new Error('Missing .env.example');
+  }
+  copyFileSync(ENV_TEMPLATE_PATH, ENV_PATH);
+  console.log(force ? '⚠︎ .env replaced from template' : '✔︎ .env created from template');
+}
+
+async function main() {
+  const options = parseOptions();
+  console.log('➡️  Bootstrapping workspace...');
+  await ensureEnv(options.forceEnv);
+
+  if (!(await commandExists('pnpm'))) {
+    throw new Error('pnpm is required. Install it via `npm install -g pnpm`.');
+  }
+
+  if (!options.skipInstall) {
+    console.log('➡️  Installing dependencies...');
+    await runCommand('pnpm', ['install']);
+  } else {
+    console.log('⏭️  Skipping install');
+  }
+
+  if (!options.skipData) {
+    console.log('➡️  Preparing demo data...');
+    await runCommand('pnpm', ['db:migrate']);
+    await runCommand('pnpm', ['db:seed']);
+    await runCommand('pnpm', ['kb:ingest']);
+  } else {
+    console.log('⏭️  Skipping data setup');
+  }
+
+  console.log('✅ Ready! Run `pnpm dev` to launch the apps.');
+}
+
+main().catch((error) => {
+  console.error('❌ Bootstrap failed');
+  console.error(error);
+  process.exit(1);
+});
+

--- a/scripts/ingest.ts
+++ b/scripts/ingest.ts
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+import { readdirSync, readFileSync } from 'fs';
+import { resolve, basename, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { initializeDatabase, getDatabase } from '@app/db';
+import { chunkText } from '@app/utils';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const ROOT = resolve(__dirname, '..');
+
+async function ingest() {
+  console.log('➡️  Ingesting knowledge base markdown...');
+  initializeDatabase();
+  const db = getDatabase();
+
+  const knowledgeDir = resolve(ROOT, 'docs/knowledge-base');
+  const files = readdirSync(knowledgeDir).filter((file) => file.endsWith('.md'));
+
+  for (const file of files) {
+    const fullPath = resolve(knowledgeDir, file);
+    const body = readFileSync(fullPath, 'utf-8');
+    const slug = basename(file, '.md');
+    const embedding = buildDeterministicEmbedding(body);
+    db.upsertKnowledgeBaseDocument({
+      slug,
+      title: toTitle(slug),
+      body,
+      embedding,
+    });
+    console.log(`   • Indexed ${slug} (${embedding.length} dims)`);
+  }
+
+  console.log('✔︎ Knowledge base ready.');
+}
+
+ingest().catch((error) => {
+  console.error('❌ Failed to ingest documentation');
+  console.error(error);
+  process.exit(1);
+});
+
+function toTitle(slug: string) {
+  return slug
+    .split('-')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function buildDeterministicEmbedding(text: string): number[] {
+  const slices = chunkText(text, 200);
+  if (!slices.length) {
+    return [0, 0, 0, 0, 0];
+  }
+  return slices.slice(0, 8).map((slice, index) => {
+    const total = Array.from(slice).reduce((sum, char) => sum + char.charCodeAt(0), 0);
+    return Math.round((total / slice.length) * (index + 1));
+  });
+}
+

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+import { initializeDatabase } from '@app/db';
+import { ensureDemoUser } from '@app/auth';
+
+async function main() {
+  console.log('➡️  Preparing lightweight demo datastore...');
+  initializeDatabase();
+  ensureDemoUser();
+  console.log('✔︎ Datastore ready.');
+}
+
+main().catch((error) => {
+  console.error('❌ Failed to initialize datastore');
+  console.error(error);
+  process.exit(1);
+});
+

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+import { Buffer } from 'node:buffer';
+import { initializeDatabase, getDatabase } from '@app/db';
+import { ensureDemoUser } from '@app/auth';
+import { createId, formatCurrency } from '@app/utils';
+import { getConfig } from '@app/config';
+import { trackEvent } from '@app/analytics';
+import { transcribeAudio } from '@app/voice';
+import { sendTransactionalEmail } from '@app/email';
+
+async function seed() {
+  console.log('➡️  Seeding demo data...');
+  initializeDatabase();
+  ensureDemoUser();
+  const db = getDatabase();
+  const config = getConfig();
+
+  const founder = db
+    .getUsers()
+    .find((user) => user.email === config.defaultUserEmail);
+
+  if (!founder) {
+    throw new Error('Demo user missing after initialization.');
+  }
+
+  console.log('   • Ensuring pricing plans');
+  const starter = db.upsertProduct({
+    name: 'Starter',
+    description: 'Launch with authentication, chat, and payments in minutes.',
+    priceCents: 2900,
+    interval: 'month',
+  });
+  const pro = db.upsertProduct({
+    name: 'Pro',
+    description: 'Unlock voice, analytics, and advanced workflows.',
+    priceCents: 9900,
+    interval: 'month',
+  });
+
+  console.log('   • Assigning subscription to demo user');
+  db.upsertSubscription({
+    userId: founder.id,
+    productId: pro.id,
+    status: 'active',
+    currentPeriodEnd: new Date(Date.now() + 1000 * 60 * 60 * 24 * 28).toISOString(),
+  });
+
+  console.log('   • Bootstrapping welcome chat thread');
+  const thread = db.upsertThread({
+    title: 'Welcome to the AI boilerplate',
+    ownerId: founder.id,
+    createdAt: new Date().toISOString(),
+  });
+
+  const existingMessages = db.getMessages(thread.id);
+  if (!existingMessages.length) {
+    db.addMessage({
+      threadId: thread.id,
+      role: 'system',
+      content: 'You are a friendly AI onboarding specialist for the boilerplate.',
+    });
+    db.addMessage({
+      threadId: thread.id,
+      role: 'user',
+      content: 'Give me a tour of what this starter kit unlocks.',
+    });
+    db.addMessage({
+      threadId: thread.id,
+      role: 'assistant',
+      content:
+        'Welcome aboard! Explore the live dashboard to try chat, payments, analytics, and voice without writing any code.',
+    });
+  }
+
+  console.log('   • Recording audit log entries');
+  db.addAuditLog({
+    actorId: founder.id,
+    action: 'user.login',
+    target: founder.email,
+    metadata: { via: 'seed-script' },
+  });
+  db.addAuditLog({
+    actorId: founder.id,
+    action: 'subscription.activated',
+    target: pro.id,
+    metadata: { amount: formatCurrency(pro.priceCents) },
+  });
+
+  console.log('   • Tracking analytics events');
+  trackEvent({ name: 'dashboard_viewed', payload: { plan: pro.name }, userId: founder.id });
+  trackEvent({ name: 'chat_started', payload: { threadId: thread.id }, userId: founder.id });
+  trackEvent({ name: 'voice_preview_played', payload: { sessionId: createId('evt') }, userId: founder.id });
+
+  console.log('   • Creating sample voice session');
+  transcribeAudio(Buffer.from('Voice session summary for the AI boilerplate.'));
+
+  console.log('   • Sending welcome email preview');
+  sendTransactionalEmail(founder.email, 'welcome-email', {
+    plan: pro.name,
+    price: formatCurrency(pro.priceCents),
+  });
+
+  console.log('✔︎ Demo data ready.');
+}
+
+seed().catch((error) => {
+  console.error('❌ Failed to seed demo data');
+  console.error(error);
+  process.exit(1);
+});
+

--- a/scripts/stripe-dev.sh
+++ b/scripts/stripe-dev.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="test"
+FORWARD_URL="http://localhost:3000/api/webhooks/stripe"
+TRIGGERS=()
+
+usage() {
+  cat <<USAGE
+Usage: $(basename "$0") [options]
+
+Options:
+  --forward-to <url>   Override the webhook forward URL (default: $FORWARD_URL)
+  --live               Listen for live mode events instead of test data
+  --trigger <event>    Trigger a specific Stripe event after the listener starts
+  -h, --help           Show this help message
+
+Examples:
+  $0 --trigger checkout.session.completed
+  $0 --live --forward-to https://example.com/api/webhooks/stripe
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --forward-to)
+      shift
+      FORWARD_URL="${1:-$FORWARD_URL}"
+      ;;
+    --live)
+      MODE="live"
+      ;;
+    --trigger)
+      shift
+      TRIGGERS+=("$1")
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+  shift || true
+done
+
+if ! command -v stripe >/dev/null 2>&1; then
+  echo "❌ stripe CLI is required. Install it via https://stripe.com/docs/stripe-cli#install" >&2
+  exit 1
+fi
+
+echo "➡️  Starting Stripe listener in $MODE mode..."
+LISTEN_FLAGS=("listen")
+[[ "$MODE" == "live" ]] && LISTEN_FLAGS+=("--live")
+LISTEN_FLAGS+=("--forward-to" "$FORWARD_URL")
+
+stripe "${LISTEN_FLAGS[@]}" &
+LISTENER_PID=$!
+trap 'kill $LISTENER_PID 2>/dev/null || true' EXIT
+
+sleep 2
+
+echo "➡️  Forwarding events to $FORWARD_URL"
+if [[ ${#TRIGGERS[@]} -gt 0 ]]; then
+  for EVENT in "${TRIGGERS[@]}"; do
+    echo "   • Triggering $EVENT"
+    stripe trigger "$EVENT"
+  done
+else
+  echo "ℹ️  No triggers specified. Use --trigger to send sample events."
+fi
+
+wait $LISTENER_PID

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "baseUrl": ".",
+    "paths": {
+      "@app/*": ["packages/*/src"]
+    },
+    "types": []
+  },
+  "include": ["packages", "apps", "scripts", "features.ts"],
+  "exclude": ["node_modules", "dist", ".turbo", "build", "coverage"]
+}

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "pipeline": {
+    "dev": {
+      "cache": false,
+      "dependsOn": ["^dev"],
+      "persistent": true
+    },
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", ".next/**", "build/**"]
+    },
+    "lint": {
+      "outputs": []
+    },
+    "test": {
+      "dependsOn": ["lint"],
+      "outputs": ["coverage/**"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- replace stub workspace packages with a JSON-backed datastore, analytics, auth, chat, payments, voice, email, and LLM helpers
- simplify bootstrap, migrate, seed, and ingest scripts to populate the new demo data
- add a Next.js dashboard that exercises all modules with a live chat panel and knowledge-base overview

## Testing
- `pnpm install` *(fails: registry proxy blocked in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d978e163d08329ac078e7f19e37361